### PR TITLE
fix(cleanup): Cleanup pass

### DIFF
--- a/ayn-platform.c
+++ b/ayn-platform.c
@@ -632,7 +632,9 @@ static struct attribute *ayn_led_mc_attrs[] = {
         NULL,
 };
 
-ATTRIBUTE_GROUPS(ayn_led_mc);
+static struct attribute_group ayn_led_mc_group = {
+      .attrs = ayn_led_mc_attrs,
+};
 
 /* Initialization logic */
 static const struct hwmon_channel_info *ayn_platform_sensors[] = {
@@ -675,7 +677,7 @@ struct mc_subled ayn_led_mc_subled_info[] = {
 
 struct led_classdev_mc ayn_led_mc = {
         .led_cdev = {
-                .name = "multicolor:chassis",
+                .name = "ayn:rgb:joystick_rings",
                 .brightness = 0,
                 .max_brightness = 255,
                 .brightness_set = ayn_led_mc_brightness_set,
@@ -713,7 +715,7 @@ static int ayn_platform_probe(struct platform_device *pdev)
 
         struct led_classdev *led_cdev = &ayn_led_mc.led_cdev;
 
-        retval = devm_device_add_group(ayn_led_mc.led_cdev.dev, *ayn_led_mc_groups);
+        retval = devm_device_add_group(ayn_led_mc.led_cdev.dev, &ayn_led_mc_group);
         if (retval)
                 return retval;
 


### PR DESCRIPTION
- Rename sysfs path to ayn:rgb:joystick_rings to allign with kernel drivers and LED naming guidance.
- Add attribute group by ref instead of pointer to groups.